### PR TITLE
added functionality to show post meta of each post on acrhive pages

### DIFF
--- a/class-debug-bar-post-meta.php
+++ b/class-debug-bar-post-meta.php
@@ -3,31 +3,46 @@
 class Debug_Bar_Post_Meta extends Debug_Bar_Panel {
 	function init() {
 		$this->title( __( 'Post Meta', 'debug-bar' ) );
+		$this->enqueue();
 	}
 
 	function render() {
-		$output = "<div id='template-trace'>";
-		$output .= "<h3>Post Meta</h3>";
-		$metas = get_post_meta( get_the_ID() );
-		$output .= '<table>';
-		foreach ( $metas as $key => $values ) {
-			$output .= '<tr>';
-			$output .= '<td>' . $key . '</td>';
-			$vals = '';
-			foreach ( $values as $value ) {
-				if ( ( is_serialized( $value ) )  !== false ) {
-					$vals .= print_r( unserialize( $value ), true );
-				} else {
-					$vals .= print_r( $value, true ) . "\n";
-				}
+		global $wp_query;
 
+		if( !empty( $wp_query->posts ) ){ 
+		// get post meta form all posts
+			$output = "<div class='template-trace' id='debug-bar-post-meta'>";
+			foreach( $wp_query->posts as $single_post ){
+				$output .= "<h3 style=''>".$single_post->post_title."</h3>";
+				$metas = get_post_meta( $single_post->ID );
+				$output .= '<table>';
+				foreach ( $metas as $key => $values ) {
+					$output .= '<tr>';
+					$output .= '<td>' . $key . '</td>';
+					$vals='';
+					foreach ( $values as $value ):
+						if ( ( is_serialized( $value ) )  !== false ) {
+							$vals .= print_r( unserialize( $value ), true );
+						} else {
+						$vals .= print_r( $value, true );
+					}
+					endforeach;
+
+					$output .= '<td><pre><code>' . esc_attr( $vals ) . '</code></pre></td>';
+					$output .= '</tr>';
+				}
+				$output .= '</table>';	
 			}
-			$output .= '<td><pre><code>' . esc_attr ( $vals ) . '</code></pre></td>';
-			$output .= '</tr>';
+			$output .= "</div>";
+		}else{
+			$output = "Their are no post/page meta for this url";
 		}
-		$output .= '</table>';
-		$output .= "</div>";
 		echo $output;
+	}
+
+
+	function enqueue() {
+		wp_enqueue_style('debug-bar-post-meta-css',plugins_url('css/debug-bar-post-meta.css',__FILE__));
 	}
 }
 

--- a/css/debug-bar-post-meta.css
+++ b/css/debug-bar-post-meta.css
@@ -1,0 +1,9 @@
+#debug-bar-post-meta h3 {
+border-bottom: 3px double gray;
+font-size: 14px;
+padding-bottom: 5px;
+font-weight: bold;
+}
+#debug-bar-post-meta table{
+	margin-bottom: 20px;
+}


### PR DESCRIPTION
This plugin is not showing post meta of each post on achrive page ( show post meta only for last post in loop ) . But now it will show post meta of all post which help's developers. and i also add some css to give Post Meta tab more readability
